### PR TITLE
Use brackets to show sample value for custom attributes

### DIFF
--- a/classes/pok.php
+++ b/classes/pok.php
@@ -385,7 +385,7 @@ class pok {
         $customparams = [];
         if ($templatedefinition && $templatedefinition->customParameters) {
             foreach ($templatedefinition->customParameters as $param) {
-                $customparams[$param->id] = '';
+                $customparams[$param->id] = $param->label;
             }
         }
 

--- a/classes/pok.php
+++ b/classes/pok.php
@@ -385,7 +385,7 @@ class pok {
         $customparams = [];
         if ($templatedefinition && $templatedefinition->customParameters) {
             foreach ($templatedefinition->customParameters as $param) {
-                $customparams[$param->id] = $param->label;
+                $customparams[$param->id] = "[ $param->label ]";
             }
         }
 


### PR DESCRIPTION
This acommodates API usage to new restrictions on required attributes